### PR TITLE
updated valid device-alias names, fixes #3, ansible/ansible#68343, and ansible/ansible#68144

### DIFF
--- a/library/nxos_devicealias.py
+++ b/library/nxos_devicealias.py
@@ -219,11 +219,15 @@ def isPwwnValid(pwwn):
 
 
 def isNameValid(name):
+    validdacharacters = '-','_','$','^'
     if not name[0].isalpha():
         # Illegal first character. Name must start with a letter
         return False
     if len(name) > 64:
         return False
+    for character in name:
+        if not character.isalnum() and character not in validdacharacters:
+            return False
     return True
 
 
@@ -298,7 +302,7 @@ def main():
                         ' which needs to be added, doenst have pwwn specified . Please specify a valid pwwn')
                 if not isNameValid(name):
                     module.fail_json(msg='This pwwn name is invalid : ' + str(name) +
-                                     '. Note that name cannot be more than 64 chars and it should start with a letter')
+                                     '. Note that name cannot be more than 64 alphanumeric chars, it must start with a letter, and can only contain "-", "_", "$", or "^" special characters')
                 if not isPwwnValid(pwwn):
                     module.fail_json(msg='This pwwn is invalid : ' + str(pwwn) + '. Please check that its a valid pwwn')
     if rename is not None:
@@ -307,10 +311,10 @@ def main():
             newname = eachdict['new_name']
             if not isNameValid(oldname):
                 module.fail_json(msg='This pwwn name is invalid : ' + str(oldname) +
-                                 '. Note that name cannot be more than 64 chars and it should start with a letter')
+                                 '. Note that name cannot be more than 64 alphanumeric chars, it must start with a letter, and can only contain "-", "_", "$", or "^" special characters')
             if not isNameValid(newname):
                 module.fail_json(msg='This pwwn name is invalid : ' + str(newname) +
-                                 '. Note that name cannot be more than 64 chars and it should start with a letter')
+                                 '. Note that name cannot be more than 64 alphanumeric chars, it must start with a letter, and can only contain "-", "_", "$", or "^" special characters')
 
     # Step 0.1: Check DA status
     shDAStausObj = showDeviceAliasStatus(module)

--- a/library/nxos_zone_zoneset.py
+++ b/library/nxos_zone_zoneset.py
@@ -425,7 +425,8 @@ def getMemType(supported_choices, allmemkeys, default='pwwn'):
     for eachchoice in supported_choices:
         if eachchoice in allmemkeys:
             return eachchoice
-    return default
+        else:
+            return default
 
 
 def main():
@@ -710,9 +711,7 @@ def main():
                     else:
                         messages.append("zoneset '" + zsetname + "' in vsan " + str(vsan) + " is not activated, hence cannot deactivate")
                 elif actionflag == 'activate':
-                    if shZonesetActiveObj.isZonesetActive(zsetname):
-                        messages.append("zoneset '" + zsetname + "' in vsan " + str(vsan) + " is already activated")
-                    else:
+                # If zoneset is set to active, activate every time
                         messages.append("activating zoneset '" + zsetname + "' in vsan " + str(vsan))
                         actcmd.append("zoneset activate name " + zsetname + " vsan " + str(vsan))
             commands_executed = commands_executed + dactcmd + actcmd

--- a/library/nxos_zone_zoneset.py
+++ b/library/nxos_zone_zoneset.py
@@ -425,8 +425,7 @@ def getMemType(supported_choices, allmemkeys, default='pwwn'):
     for eachchoice in supported_choices:
         if eachchoice in allmemkeys:
             return eachchoice
-        else:
-            return default
+    return default
 
 
 def main():

--- a/library/nxos_zone_zoneset.py
+++ b/library/nxos_zone_zoneset.py
@@ -100,7 +100,6 @@ options:
                         description:
                             - activates/de-activates the zoneset
                         choices: ['activate', 'deactivate']
-                        default: 'deactivate'
                     members:
                         description:
                             - Members of the zoneset that needs to be removed or added


### PR DESCRIPTION
updated the isNameValid function to check for valid characters according to the Cisco MDS 9000 Family NX-OS Fabric Configuration Guide:



"Device Alias Requirements
Device aliases have the following requirements:

You can only assign device aliases to pWWNs.
The mapping between the pWWN and the device alias to which it is mapped must have a one-to-one relationship. A pWWN can be mapped to only one device alias and vice versa.
A device alias name is restricted to 64 alphanumeric characters and may include one or more of the following characters:
– a to z and A to Z

– 1 to 9

– - (hyphen) and _ (underscore)

–$ (dollar sign) and ^ (up caret)"